### PR TITLE
I've refactored the APIClient to use simulated time for rate limiting.

### DIFF
--- a/src/simulator.py
+++ b/src/simulator.py
@@ -35,7 +35,8 @@ class Simulator:
         # 必要であればPriorityQueueStrategyを改修し、内部キューのサイズ制限を設定できるようにする必要があります。
 
         # APIClientのインスタンスを作成 (全ワーカーで共有)
-        self.api_client = APIClient()
+        # simulator_time_func として self.get_current_time を渡す
+        self.api_client = APIClient(simulator_time_func=self.get_current_time)
 
         self.workers: List[Worker] = [
             Worker(worker_id=i, task_queue=self.task_queue, api_client=self.api_client)
@@ -77,6 +78,10 @@ class Simulator:
                 next_event_time = min(next_event_time, worker.busy_until)
 
         return next_event_time
+
+    def get_current_time(self) -> float:
+        """現在のシミュレーション時刻を返す。"""
+        return self.current_time
 
     def run(self) -> List[Request]:
         """
@@ -179,7 +184,6 @@ class Simulator:
                     # print("--- Simulation End: All tasks processed and no pending. ---")
                     break # All tasks processed
                 pass
-
 
         self.completed_requests.sort(key=lambda r: (r.finish_processing_time_by_worker if r.finish_processing_time_by_worker != -1 else float('inf'), r.arrival_time_in_queue))
         # print(f"Total completed (incl. rejected): {len(self.completed_requests)}")

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -10,10 +10,10 @@ class TestAPIClient(unittest.TestCase):
 
     @patch('src.api_client.EXTERNAL_API_RPM_LIMIT', 10)
     @patch('src.api_client.NUM_EXTERNAL_APIS', 3)
-    @patch('src.api_client.time') # timeモジュール自体ではなく、time.time()をモックするためにtime.timeをパッチ
-    def test_initialization_with_settings(self, mock_time_module_time_method):
-        # mock_time_module_time_method は src.api_client.time.time のモック
-        client = APIClient()
+    def test_initialization_with_settings(self): # timeのモックは不要になった
+        # APIClientのコンストラクタは simulator_time_func を必要とする
+        mock_time_func = MagicMock(return_value=0) # 簡単なモック時間関数
+        client = APIClient(simulator_time_func=mock_time_func)
         self.assertEqual(client.num_apis, 3)
         self.assertEqual(client.rpm_limit, 10)
         self.assertEqual(len(client.api_endpoints), 3)
@@ -21,10 +21,11 @@ class TestAPIClient(unittest.TestCase):
 
     @patch('src.api_client.EXTERNAL_API_RPM_LIMIT', 2)
     @patch('src.api_client.NUM_EXTERNAL_APIS', 1)
-    @patch('src.api_client.time')
-    def test_rate_limit_single_api(self, mock_time_module):
-        mock_time_module.time.side_effect = [t/10.0 for t in range(100)] # time.time()が返す値
-        client = APIClient()
+    def test_rate_limit_single_api(self): # timeのモックは不要になった
+        mock_time_func = MagicMock()
+        # simulator_time_func が呼ばれるたびに異なる値を返すように設定
+        mock_time_func.side_effect = [t/10.0 for t in range(100)]
+        client = APIClient(simulator_time_func=mock_time_func)
 
         response1 = client.make_request({"data": "req1"})
         self.assertEqual(response1["api_used_id"], 1)
@@ -39,10 +40,10 @@ class TestAPIClient(unittest.TestCase):
 
     @patch('src.api_client.EXTERNAL_API_RPM_LIMIT', 1)
     @patch('src.api_client.NUM_EXTERNAL_APIS', 2)
-    @patch('src.api_client.time')
-    def test_fallback_mechanism(self, mock_time_module):
-        mock_time_module.time.side_effect = [t * 0.1 for t in range(100)]
-        client = APIClient()
+    def test_fallback_mechanism(self): # timeのモックは不要になった
+        mock_time_func = MagicMock()
+        mock_time_func.side_effect = [t * 0.1 for t in range(100)]
+        client = APIClient(simulator_time_func=mock_time_func)
 
         # 1回目: API 1 を使用
         # print("Fallback test: Request 1")
@@ -70,10 +71,10 @@ class TestAPIClient(unittest.TestCase):
 
     @patch('src.api_client.EXTERNAL_API_RPM_LIMIT', 1)
     @patch('src.api_client.NUM_EXTERNAL_APIS', 2)
-    @patch('src.api_client.time')
-    def test_all_apis_rate_limited_then_exception(self, mock_time_module):
-        mock_time_module.time.side_effect = [t * 0.1 for t in range(100)]
-        client = APIClient()
+    def test_all_apis_rate_limited_then_exception(self): # timeのモックは不要になった
+        mock_time_func = MagicMock()
+        mock_time_func.side_effect = [t * 0.1 for t in range(100)]
+        client = APIClient(simulator_time_func=mock_time_func)
 
         # API 1 を使用 (成功)
         client.make_request({"data": "req1"}) # API 1 (index 0) を使用, current_api_index = 0
@@ -102,25 +103,25 @@ class TestAPIClient(unittest.TestCase):
 
     @patch('src.api_client.EXTERNAL_API_RPM_LIMIT', 1)
     @patch('src.api_client.NUM_EXTERNAL_APIS', 1)
-    @patch('src.api_client.time')
-    def test_rate_limit_reset_after_one_minute(self, mock_time_module):
-        client = APIClient()
+    def test_rate_limit_reset_after_one_minute(self): # timeのモックは不要になった
+        mock_time_func = MagicMock()
+        client = APIClient(simulator_time_func=mock_time_func)
 
         # 最初の時間
-        mock_time_module.time.return_value = 0.0
+        mock_time_func.return_value = 0.0
         response1 = client.make_request({"data": "req1"})
         self.assertEqual(response1["api_used_id"], 1)
         self.assertEqual(len(client.request_timestamps[0]), 1)
         self.assertEqual(client.request_timestamps[0][0], 0.0)
 
         # 10秒経過 (レート制限内)
-        mock_time_module.time.return_value = 10.0
+        mock_time_func.return_value = 10.0
         with self.assertRaisesRegex(Exception, "All external APIs are unavailable or rate limited."):
             client.make_request({"data": "req2_rate_limited"})
         self.assertEqual(len(client.request_timestamps[0]), 1) # タイムスタンプは追加されない
 
         # 60.1秒経過 (最初の呼び出しから1分以上経過)
-        mock_time_module.time.return_value = 60.1
+        mock_time_func.return_value = 60.1
         response3 = client.make_request({"data": "req3_after_reset"})
         self.assertEqual(response3["api_used_id"], 1)
         # 古いタイムスタンプ(0.0)はpopされ、新しいタイムスタンプ(60.1)が入るので長さは1


### PR DESCRIPTION
Previously, the APIClient's rate limiting relied on real time, which wasn't ideal for simulations. I've adjusted the APIClient to accept a time-providing function during its setup.

Here's a summary of the changes:
- The APIClient now accepts a `simulator_time_func` when it's created.
- Internal time checks and timestamping now use this provided function.
- The Simulator class has been updated to provide its `current_time` to the APIClient.
- I've updated the tests in `tests/test_api_client.py` to mock the time function passed to the APIClient, ensuring they work with the new setup and correctly test time-dependent logic.